### PR TITLE
Update spdlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bower_components
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build
+bin
 
 # Dependency directories
 node_modules/

--- a/binding.gyp
+++ b/binding.gyp
@@ -17,7 +17,7 @@
 					'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
 				}
 			}],
-			['OS=="windows"', {
+			['OS=="win"', {
 				'defines': [
 					'SPDLOG_WCHAR_FILENAMES'
 				]

--- a/binding.gyp
+++ b/binding.gyp
@@ -16,6 +16,11 @@
 				'xcode_settings': {
 					'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
 				}
+			}],
+			['OS=="windows"', {
+				'defines': [
+					'SPDLOG_WCHAR_FILENAMES'
+				]
 			}]
 		]
 	}]

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,11 @@ export const version: number;
 export function setFlushEvery(seconds: number);
 export function setLevel(level: number);
 export function shutdown();
-export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<RotatingLogger>;
+export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<Logger>;
+export function createAsyncRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<Logger>;
 
 export class Logger {
-    constructor(loggerType: "rotating" | "stdout", name: string, filename: string, filesize: number, filecount: number);
+    constructor(loggerType: "rotating" | "rotating_async" | "stdout_async", name: string, filename: string, filesize: number, filecount: number);
 
     trace(message: string): void;
     debug(message: string): void;
@@ -19,7 +20,9 @@ export class Logger {
     warn(message: string): void;
     error(message: string): void;
     critical(message: string): void;
+    getLevel(): number;
     setLevel(level: number): void;
+    setPattern(pattern: string): void;
     clearFormatters(): void;
     /**
      * A synchronous operation to flush the contents into file

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const version: number;
-export function setFlushEvery(seconds: number);
 export function setLevel(level: number);
 export function shutdown();
 export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<Logger>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,10 @@ export const version: number;
 export function setFlushEvery(seconds: number);
 export function setLevel(level: number);
 export function shutdown();
-export function createAsyncRotatingLoggerAsync(name: string, filename: string, filesize: number, filecount: number): Promise<RotatingLogger>;
+export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): Promise<RotatingLogger>;
 
 export class Logger {
-    constructor(loggerType: "rotating" | "rotating_async" | "stdout", name: string, filename: string, filesize: number, filecount: number);
+    constructor(loggerType: "rotating" | "stdout", name: string, filename: string, filesize: number, filecount: number);
 
     trace(message: string): void;
     debug(message: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,13 +4,14 @@
  *  license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const version: string;
-export function setAsyncMode(bufferSize: number, flushInterval: number): void;
-export function createRotatingLogger(name: string, filename: string, filesize: number, filecount: number): RotatingLogger;
-export function createRotatingLoggerAsync(name: string, filename: string, filesize: number, filecount: number): Promise<RotatingLogger>;
+export const version: number;
+export function setFlushEvery(seconds: number);
+export function setLevel(level: number);
+export function shutdown();
+export function createAsyncRotatingLoggerAsync(name: string, filename: string, filesize: number, filecount: number): Promise<RotatingLogger>;
 
-export class RotatingLogger {
-    constructor(name: string, filename: string, filesize: number, filecount: number);
+export class Logger {
+    constructor(loggerType: "rotating" | "rotating_async" | "stdout", name: string, filename: string, filesize: number, filecount: number);
 
     trace(message: string): void;
     debug(message: string): void;

--- a/index.js
+++ b/index.js
@@ -9,16 +9,25 @@ exports.shutdown = spdlog.shutdown;
 exports.Logger = spdlog.Logger;
 
 function createRotatingLogger(name, filepath, maxFileSize, maxFiles) {
+	return createLogger('rotating', name, filepath, maxFileSize, maxFiles);
+}
+
+function createAsyncRotatingLogger(name, filepath, maxFileSize, maxFiles) {
+	return createLogger('rotating_async', name, filepath, maxFileSize, maxFiles);
+}
+
+function createLogger(loggerType, name, filepath, maxFileSize, maxFiles) {
 	return new Promise((c, e) => {
 		const dirname = path.dirname(filepath);
 		mkdirp(dirname, err => {
 			if (err) {
 				e(err);
 			} else {
-				c(new spdlog.Logger('rotating', name, filepath, maxFileSize, maxFiles));
+				c(new spdlog.Logger(loggerType, name, filepath, maxFileSize, maxFiles));
 			}
-		})
+		});
 	});
 }
 
 exports.createRotatingLogger = createRotatingLogger;
+exports.createAsyncRotatingLogger = createAsyncRotatingLogger;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ const mkdirp = require('mkdirp');
 const spdlog = require('bindings')('spdlog');
 
 exports.version = spdlog.version;
-exports.setFlushEvery = spdlog.setFlushEvery;
 exports.setLevel = spdlog.setLevel;
 exports.shutdown = spdlog.shutdown;
 exports.Logger = spdlog.Logger;

--- a/index.js
+++ b/index.js
@@ -3,37 +3,22 @@ const mkdirp = require('mkdirp');
 const spdlog = require('bindings')('spdlog');
 
 exports.version = spdlog.version;
-exports.initThreadPool = spdlog.initThreadPool;
+exports.setFlushEvery = spdlog.setFlushEvery;
 exports.setLevel = spdlog.setLevel;
+exports.shutdown = spdlog.shutdown;
 exports.Logger = spdlog.Logger;
 
-class RotatingLogger extends spdlog.Logger {
-	constructor(name, filename, maxFileSize, maxFiles) {
-		if (path.isAbsolute(filename)) {
-			mkdirp.sync(path.dirname(filename));
-		}
-
-		super('rotating', name, filename, maxFileSize, maxFiles);
-	}
-}
-
-function createRotatingLoggerAsync(name, filepath, maxFileSize, maxFiles) {
+function createAsyncRotatingLoggerAsync(name, filepath, maxFileSize, maxFiles) {
 	return new Promise((c, e) => {
 		const dirname = path.dirname(filepath);
 		mkdirp(dirname, err => {
 			if (err) {
 				e(err);
 			} else {
-				c(createRotatingLogger(name, filepath, maxFileSize, maxFiles));
+				c(new spdlog.Logger('rotating_async', name, filepath, maxFileSize, maxFiles));
 			}
 		})
 	});
 }
 
-function createRotatingLogger(name, filepath, maxFileSize, maxFiles) {
-	return new spdlog.Logger('rotating', name, filepath, maxFileSize, maxFiles);
-}
-
-exports.createRotatingLoggerAsync = createRotatingLoggerAsync;
-exports.createRotatingLogger = createRotatingLogger;
-exports.RotatingLogger = RotatingLogger;
+exports.createAsyncRotatingLoggerAsync = createAsyncRotatingLoggerAsync;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const mkdirp = require('mkdirp');
 const spdlog = require('bindings')('spdlog');
 
 exports.version = spdlog.version;
-exports.setAsyncMode = spdlog.setAsyncMode;
+exports.initThreadPool = spdlog.initThreadPool;
 exports.setLevel = spdlog.setLevel;
 exports.Logger = spdlog.Logger;
 

--- a/index.js
+++ b/index.js
@@ -8,17 +8,17 @@ exports.setLevel = spdlog.setLevel;
 exports.shutdown = spdlog.shutdown;
 exports.Logger = spdlog.Logger;
 
-function createAsyncRotatingLoggerAsync(name, filepath, maxFileSize, maxFiles) {
+function createRotatingLogger(name, filepath, maxFileSize, maxFiles) {
 	return new Promise((c, e) => {
 		const dirname = path.dirname(filepath);
 		mkdirp(dirname, err => {
 			if (err) {
 				e(err);
 			} else {
-				c(new spdlog.Logger('rotating_async', name, filepath, maxFileSize, maxFiles));
+				c(new spdlog.Logger('rotating', name, filepath, maxFileSize, maxFiles));
 			}
 		})
 	});
 }
 
-exports.createAsyncRotatingLoggerAsync = createAsyncRotatingLoggerAsync;
+exports.createRotatingLogger = createRotatingLogger;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,1027 @@
 {
   "name": "spdlog",
   "version": "0.11.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "spdlog",
+      "version": "0.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "mkdirp": "^0.5.5",
+        "nan": "^2.14.0"
+      },
+      "devDependencies": {
+        "@types/mocha": "^2.2.44",
+        "@types/node": "^8.0.53",
+        "mocha": "^6.2.3"
+      }
+    },
+    "node_modules/@types/mocha": {
+      "version": "2.2.44",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.44.tgz",
+      "integrity": "sha512-k2tWTQU8G4+iSMvqKi0Q9IIsWAp/n8xzdZS4Q4YVIltApoMA00wFBFdlJnmoaK1/z7B0Cy0yPe6GgXteSmdUNw==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "8.0.53",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
+      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
+      "dev": true
+    },
+    "node_modules/ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "dependencies": {
+        "object-keys": "^1.0.12"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "node_modules/es-abstract": {
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "dev": true,
+      "dependencies": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "~2.0.3"
+      },
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.x"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mocha": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.3.tgz",
+      "integrity": "sha512-0R/3FvjIGH3eEuG17ccFPk117XL2rWxatr81a57D+r/x2uTYZRbdZ4oVidEUMh2W2TJDa7MdAb12Lm2/qrKajg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.4",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mocha/node_modules/mkdirp": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "node_modules/nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
+    "node_modules/node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "dependencies": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
+      "dev": true
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
+    "node_modules/yargs": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "dependencies": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^7.0.1",
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
   "dependencies": {
     "@types/mocha": {
       "version": "2.2.44",

--- a/package-lock.json
+++ b/package-lock.json
@@ -753,9 +753,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
-      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -112,7 +112,7 @@ NAN_METHOD(Logger::New) {
       const std::string name = *Nan::Utf8String(info[0]);
       std::shared_ptr<spdlog::logger> logger;
 
-      if (name == "rotating" || name == "rotating_async") {
+      if (name == "rotating") {
         if (!info[1]->IsString() || !info[2]->IsString()) {
           return Nan::ThrowError(
               Nan::Error("Provide the log name and file name"));
@@ -134,18 +134,12 @@ NAN_METHOD(Logger::New) {
           const std::string fileName = *Nan::Utf8String(info[2]);
 #endif
 
-          if (name == "rotating_async") {
-            logger = spdlog::rotating_logger_st<spdlog::async_factory>(
-                logName, fileName, Nan::To<int64_t>(info[3]).FromJust(),
-                Nan::To<int64_t>(info[4]).FromJust());
-          } else {
-            logger = spdlog::rotating_logger_st(
-                logName, fileName, Nan::To<int64_t>(info[3]).FromJust(),
-                Nan::To<int64_t>(info[4]).FromJust());
-          }
+          logger = spdlog::rotating_logger_st<spdlog::async_factory>(
+              logName, fileName, Nan::To<int64_t>(info[3]).FromJust(),
+            Nan::To<int64_t>(info[4]).FromJust());
         }
       } else {
-        logger = spdlog::stdout_logger_st(name);
+        logger = spdlog::stdout_logger_st<spdlog::async_factory>(name);
       }
       Logger *obj = new Logger(logger);
       obj->Wrap(info.This());

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -4,21 +4,24 @@
  *  license information.
  *--------------------------------------------------------------------------------------------*/
 
+#include <spdlog/async.h>
+#include <spdlog/sinks/rotating_file_sink.h>
+#include <spdlog/sinks/stdout_sinks.h>
+
 #include "logger.h"
 
-NAN_METHOD(setAsyncMode) {
+NAN_METHOD(initThreadPool) {
   if (!info[0]->IsNumber()) {
     return Nan::ThrowError(Nan::Error("Provide queue size as first parameter"));
   }
   if (!info[1]->IsNumber()) {
     return Nan::ThrowError(Nan::Error(
-        "Provide a flush interval in milliseconds as second parameter"));
+        "Provide thread count as second parameter"));
   }
 
-  spdlog::set_async_mode(
+  spdlog::init_thread_pool(
       Nan::To<int64_t>(info[0]).FromJust(),
-      spdlog::async_overflow_policy::block_retry, nullptr,
-      std::chrono::milliseconds(Nan::To<int64_t>(info[1]).FromJust()));
+      Nan::To<int64_t>(info[1]).FromJust());
 }
 
 NAN_METHOD(setLevel) {
@@ -59,8 +62,7 @@ NAN_METHOD(setLevel) {
 Nan::Persistent<v8::Function> Logger::constructor;
 
 NAN_MODULE_INIT(Logger::Init) {
-  spdlog::set_async_mode(8192, spdlog::async_overflow_policy::block_retry,
-                         nullptr, std::chrono::seconds(1));
+  spdlog::init_thread_pool(8192, 1);
 
   v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
   tpl->SetClassName(Nan::New("Logger").ToLocalChecked());

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -52,7 +52,7 @@ NAN_METHOD(setFlushEvery) {
   }
 
   const int64_t numberValue = Nan::To<int64_t>(info[0]).FromJust();
-  std::chrono::seconds interval = std::chrono::duration<int64_t>(numberValue);
+  std::chrono::seconds interval(numberValue);
   spdlog::flush_every(interval);
 }
 
@@ -112,7 +112,7 @@ NAN_METHOD(Logger::New) {
       const std::string name = *Nan::Utf8String(info[0]);
       std::shared_ptr<spdlog::logger> logger;
 
-      if (name == "rotating") {
+      if (name == "rotating" || name == "rotating_async") {
         if (!info[1]->IsString() || !info[2]->IsString()) {
           return Nan::ThrowError(
               Nan::Error("Provide the log name and file name"));
@@ -134,9 +134,15 @@ NAN_METHOD(Logger::New) {
           const std::string fileName = *Nan::Utf8String(info[2]);
 #endif
 
-          logger = spdlog::rotating_logger_st<spdlog::async_factory>(
+          if (logName == "rotating_async") {
+            logger = spdlog::rotating_logger_st<spdlog::async_factory>(
               logName, fileName, Nan::To<int64_t>(info[3]).FromJust(),
-            Nan::To<int64_t>(info[4]).FromJust());
+              Nan::To<int64_t>(info[4]).FromJust());
+          } else {
+            logger = spdlog::rotating_logger_st(
+              logName, fileName, Nan::To<int64_t>(info[3]).FromJust(),
+              Nan::To<int64_t>(info[4]).FromJust());
+          }
         }
       } else {
         logger = spdlog::stdout_logger_st<spdlog::async_factory>(name);

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -5,6 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 #include <chrono>
+#include <codecvt>
 #include <spdlog/async.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -5,12 +5,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 #include <chrono>
-#include <codecvt>
 #include <spdlog/async.h>
 #include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_sinks.h>
 
 #include "logger.h"
+
+#if defined(_WIN32)
+#include <codecvt>
+#endif
 
 NAN_METHOD(setLevel) {
   if (!info[0]->IsNumber()) {

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -50,16 +50,6 @@ NAN_METHOD(setLevel) {
   spdlog::set_level(level);
 }
 
-NAN_METHOD(setFlushEvery) {
-  if (!info[0]->IsNumber()) {
-    return Nan::ThrowError(Nan::Error("Provide number of seconds between flushes"));
-  }
-
-  const int64_t numberValue = Nan::To<int64_t>(info[0]).FromJust();
-  std::chrono::seconds interval(numberValue);
-  spdlog::flush_every(interval);
-}
-
 NAN_METHOD(shutdown) {
   spdlog::shutdown();
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -54,7 +54,7 @@ class Logger : public Nan::ObjectWrap {
 
 class VoidFormatter : public spdlog::formatter {
   void format(const spdlog::details::log_msg &msg, spdlog::memory_buf_t &dest) override {
-    dest.append(msg.payload.begin(), msg.payload.end());
+    spdlog::details::fmt_helper::append_string_view(msg.payload, dest);
   }
 
   std::unique_ptr<spdlog::formatter> clone() const override {

--- a/src/logger.h
+++ b/src/logger.h
@@ -19,8 +19,9 @@
 
 #include <spdlog/spdlog.h>
 
-NAN_METHOD(initThreadPool);
 NAN_METHOD(setLevel);
+NAN_METHOD(setFlushEvery);
+NAN_METHOD(shutdown);
 
 class Logger : public Nan::ObjectWrap {
  public:

--- a/src/logger.h
+++ b/src/logger.h
@@ -19,7 +19,7 @@
 
 #include <spdlog/spdlog.h>
 
-NAN_METHOD(setAsyncMode);
+NAN_METHOD(initThreadPool);
 NAN_METHOD(setLevel);
 
 class Logger : public Nan::ObjectWrap {
@@ -52,9 +52,12 @@ class Logger : public Nan::ObjectWrap {
 };
 
 class VoidFormatter : public spdlog::formatter {
-  void format(spdlog::details::log_msg &msg) override {
-    msg.formatted << fmt::StringRef(msg.raw.data(), msg.raw.size());
-    msg.formatted.write("", -1);
+  void format(const spdlog::details::log_msg &msg, spdlog::memory_buf_t &dest) override {
+    dest.append(msg.payload.begin(), msg.payload.end());
+  }
+
+  std::unique_ptr<spdlog::formatter> clone() const override {
+    return spdlog::details::make_unique<VoidFormatter>();
   }
 };
 

--- a/src/logger.h
+++ b/src/logger.h
@@ -20,7 +20,6 @@
 #include <spdlog/spdlog.h>
 
 NAN_METHOD(setLevel);
-NAN_METHOD(setFlushEvery);
 NAN_METHOD(shutdown);
 
 class Logger : public Nan::ObjectWrap {

--- a/src/main.cc
+++ b/src/main.cc
@@ -10,7 +10,6 @@
 NAN_MODULE_INIT(Init) {
   Nan::Set(target, Nan::New("version").ToLocalChecked(), Nan::New(SPDLOG_VERSION));
   Nan::SetMethod(target, "setLevel", setLevel);
-  Nan::SetMethod(target, "setFlushEvery", setFlushEvery);
   Nan::SetMethod(target, "shutdown", shutdown);
 
   Logger::Init(target);

--- a/src/main.cc
+++ b/src/main.cc
@@ -8,14 +8,9 @@
 #include "logger.h"
 
 NAN_MODULE_INIT(Init) {
-  Nan::Set(target, Nan::New("version").ToLocalChecked(),
-           Nan::New(SPDLOG_VERSION).ToLocalChecked());
-  Nan::Set(target, Nan::New("setAsyncMode").ToLocalChecked(),
-           Nan::GetFunction(Nan::New<v8::FunctionTemplate>(setAsyncMode))
-               .ToLocalChecked());
-  Nan::Set(target, Nan::New("setLevel").ToLocalChecked(),
-           Nan::GetFunction(Nan::New<v8::FunctionTemplate>(setLevel))
-               .ToLocalChecked());
+  Nan::Set(target, Nan::New("version").ToLocalChecked(), Nan::New(SPDLOG_VERSION));
+  Nan::SetMethod(target, "initThreadPool", initThreadPool);
+  Nan::SetMethod(target, "setLevel", setLevel);
 
   Logger::Init(target);
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -9,8 +9,9 @@
 
 NAN_MODULE_INIT(Init) {
   Nan::Set(target, Nan::New("version").ToLocalChecked(), Nan::New(SPDLOG_VERSION));
-  Nan::SetMethod(target, "initThreadPool", initThreadPool);
   Nan::SetMethod(target, "setLevel", setLevel);
+  Nan::SetMethod(target, "setFlushEvery", setFlushEvery);
+  Nan::SetMethod(target, "shutdown", shutdown);
 
   Logger::Init(target);
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -53,20 +53,8 @@ suite('API', function () {
 		});
 	});
 
-	test('is loaded', function () {
-		const spdloghPath = path.join(__dirname, '..', 'deps', 'spdlog', 'include', 'spdlog', 'common.h');
-		const contents = fs.readFileSync(spdloghPath, 'utf8');
-		const version = /SPDLOG_VERSION "([\d\.]+)"/.exec(contents)[1];
-
-		assert.equal(spdlog.version, version);
-	});
-
-	test('is loaded', function () {
-		const spdloghPath = path.join(__dirname, '..', 'deps', 'spdlog', 'include', 'spdlog', 'common.h');
-		const contents = fs.readFileSync(spdloghPath, 'utf8');
-		const version = /SPDLOG_VERSION "([\d\.]+)"/.exec(contents)[1];
-
-		assert.equal(spdlog.version, version);
+	test('Version', function () {
+		assert.strictEqual(spdlog.version, 10805);
 	});
 
 	test('Logger is present', function () {
@@ -133,25 +121,25 @@ suite('API', function () {
 	test('set level', async function () {
 		testObject = await aTestObject(logFile);
 		testObject.setLevel(0);
-		assert.equal(testObject.getLevel(), 0);
+		assert.strictEqual(testObject.getLevel(), 0);
 
 		testObject.setLevel(1);
-		assert.equal(testObject.getLevel(), 1);
+		assert.strictEqual(testObject.getLevel(), 1);
 
 		testObject.setLevel(2);
-		assert.equal(testObject.getLevel(), 2);
+		assert.strictEqual(testObject.getLevel(), 2);
 
 		testObject.setLevel(3);
-		assert.equal(testObject.getLevel(), 3);
+		assert.strictEqual(testObject.getLevel(), 3);
 
 		testObject.setLevel(4);
-		assert.equal(testObject.getLevel(), 4);
+		assert.strictEqual(testObject.getLevel(), 4);
 
 		testObject.setLevel(5);
-		assert.equal(testObject.getLevel(), 5);
+		assert.strictEqual(testObject.getLevel(), 5);
 
 		testObject.setLevel(6);
-		assert.equal(testObject.getLevel(), 6);
+		assert.strictEqual(testObject.getLevel(), 6);
 	});
 
 	test('Off Log', async function () {
@@ -237,7 +225,7 @@ suite('API', function () {
 	});
 
 	test('set async mode', function () {
-		spdlog.setAsyncMode(8192, 2000);
+		spdlog.initThreadPool(8192, 1);
 	});
 
 	test('set pattern', async function () {
@@ -248,7 +236,7 @@ suite('API', function () {
 		testObject.info('This message should be written as is');
 
 		const actual = await getLastLine();
-		assert.equal(actual, 'This message should be written as is');
+		assert.strictEqual(actual, 'This message should be written as is');
 	});
 
 	test('clear formatters', async function () {
@@ -263,7 +251,7 @@ suite('API', function () {
 		testObject.info('as is');
 
 		const actuals = await getAllLines();
-		assert.equal(actuals[actuals.length - 1], 'Cleared Formatters: This message should be written as is');
+		assert.strictEqual(actuals[actuals.length - 1], 'Cleared Formatters: This message should be written as is');
 	});
 
 	test('create log file with special characters in file name', function () {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -46,6 +46,7 @@ suite('API', function () {
 	});
 
 	suiteTeardown(() => {
+		spdlog.shutdown();
 		filesToDelete.forEach(file => {
 			if (fs.existsSync(file)) {
 				fs.unlinkSync(file);
@@ -55,6 +56,10 @@ suite('API', function () {
 
 	test('Version', function () {
 		assert.strictEqual(spdlog.version, 10805);
+	});
+
+	test('SetFlushEvery', function() {
+		spdlog.setFlushEvery(1);
 	});
 
 	test('Logger is present', function () {
@@ -224,10 +229,6 @@ suite('API', function () {
 		testObject = await aTestObject(logFile);
 	});
 
-	test('set async mode', function () {
-		spdlog.initThreadPool(8192, 1);
-	});
-
 	test('set pattern', async function () {
 		testObject = await aTestObject(logFile);
 
@@ -257,7 +258,7 @@ suite('API', function () {
 	test('create log file with special characters in file name', function () {
 		let file = path.join(__dirname, 'abcdø', 'test.log');
 		filesToDelete.push(file);
-		testObject = new spdlog.RotatingLogger('test', file, 1048576 * 5, 2);
+		testObject = new spdlog.Logger('rotating', 'test', file, 1048576 * 5, 2);
 	});
 
 	async function getLastLine() {
@@ -266,7 +267,7 @@ suite('API', function () {
 	}
 
 	async function aTestObject(logfile) {
-		const logger = await spdlog.createRotatingLoggerAsync('test', logfile, 1048576 * 5, 2);
+		const logger = await spdlog.createAsyncRotatingLoggerAsync('test', logfile, 1048576 * 5, 2);
 		logger.setPattern('%+');
 		return logger;
 	}
@@ -277,5 +278,4 @@ suite('API', function () {
 		testObject = await aTestObject(logFile);
 		return content.split(EOL);
 	}
-
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -255,11 +255,16 @@ suite('API', function () {
 		assert.strictEqual(actuals[actuals.length - 1], 'Cleared Formatters: This message should be written as is');
 	});
 
-	test('create log file with special characters in file name', async function () {
+	test('create log file with special characters in file name', function () {
 		let file = path.join(__dirname, 'abcdø', 'test.log');
 		filesToDelete.push(file);
 		testObject = new spdlog.Logger('rotating', 'test', file, 1048576 * 5, 2);
 		assert.ok(testObject);
+	});
+
+	test('create log file with special characters in file name await', async function () {
+		let file = path.join(__dirname, 'abcdø', 'test.log');
+		filesToDelete.push(file);
 		testObject = await spdlog.createRotatingLogger('test', file, 1048576 * 5, 2);
 		assert.ok(testObject);
 	});

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -58,10 +58,6 @@ suite('API', function () {
 		assert.strictEqual(spdlog.version, 10805);
 	});
 
-	test('SetFlushEvery', function() {
-		spdlog.setFlushEvery(1);
-	});
-
 	test('Logger is present', function () {
 		assert(typeof spdlog.Logger === 'function');
 	});

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -267,7 +267,7 @@ suite('API', function () {
 	}
 
 	async function aTestObject(logfile) {
-		const logger = await spdlog.createAsyncRotatingLoggerAsync('test', logfile, 1048576 * 5, 2);
+		const logger = await spdlog.createRotatingLogger('test', logfile, 1048576 * 5, 2);
 		logger.setPattern('%+');
 		return logger;
 	}

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -255,10 +255,13 @@ suite('API', function () {
 		assert.strictEqual(actuals[actuals.length - 1], 'Cleared Formatters: This message should be written as is');
 	});
 
-	test('create log file with special characters in file name', function () {
+	test('create log file with special characters in file name', async function () {
 		let file = path.join(__dirname, 'abcdø', 'test.log');
 		filesToDelete.push(file);
 		testObject = new spdlog.Logger('rotating', 'test', file, 1048576 * 5, 2);
+		assert.ok(testObject);
+		testObject = await spdlog.createRotatingLogger('test', file, 1048576 * 5, 2);
+		assert.ok(testObject);
 	});
 
 	async function getLastLine() {
@@ -267,7 +270,7 @@ suite('API', function () {
 	}
 
 	async function aTestObject(logfile) {
-		const logger = await spdlog.createRotatingLogger('test', logfile, 1048576 * 5, 2);
+		const logger = await spdlog.createAsyncRotatingLogger('test', logfile, 1048576 * 5, 2);
 		logger.setPattern('%+');
 		return logger;
 	}


### PR DESCRIPTION
This PR updates the spdlog submodule to v1.8.5, and fixes our code where needed.

- We now have an `initThreadPool` method rather than a `setAsyncMode` method.
- The implementation of the `VoidFormatter` has also changed.

Affects https://github.com/microsoft/vscode/issues/121513

I tested my changes by running `npm rebuild` and then `npm run test` using node v15.14.0. I did not use `electron-rebuild`, because I couldn't find a way to issue `npm run test` commands after running it; I'd get messages like
```
Error: The module '/Users/raymondzhao/work/node-spdlog/build/Release/spdlog.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 88. This version of Node.js requires
NODE_MODULE_VERSION 83.
```
if I used electron-rebuild or node v14.16.0.

Maybe this means that the `spdlog` submodule has to somehow be rebuilt with the right version of node, though I'm not sure how.
