### PR TITLE
Typo "Node.JS"→"Node.js"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # node-spdlog
 
-Spdlog bindings for Node.JS
+Spdlog bindings for Node.js
 
 [![Build Status](https://dev.azure.com/vscode/node-spdlog/_apis/build/status/microsoft.node-spdlog?branchName=main)](https://dev.azure.com/vscode/node-spdlog/_build/latest?definitionId=27&branchName=main)
 


### PR DESCRIPTION
https://github.com/microsoft/node-spdlog/blob/main/README.md 
#PingMSFTDocs