### PR TITLE
fix: add preinstall script for pipelines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "spdlog",
       "version": "0.13.8",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ui": "tdd"
   },
   "scripts": {
+    "preinstall": "git submodule update --init",
     "dev": "cp -R ~/.node-gyp/$(node -p 'process.versions.node')/include/node deps/node",
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "preinstall": "git submodule update --init",
+    "install": "node-gyp rebuild",
     "dev": "cp -R ~/.node-gyp/$(node -p 'process.versions.node')/include/node deps/node",
     "test": "mocha"
   },


### PR DESCRIPTION
I accidentally [the spdlog pipeline](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=205832&view=logs&j=dfaad7f5-3637-5153-b841-4c4b8f213241&t=d28e80b2-aae8-57eb-8642-266138eaa64c) because it couldn't find the submodule