### PR TITLE
fix: installation from npm published package

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -3,7 +3,9 @@ steps:
   inputs:
     versionSpec: "16.x"
 
-- script: npm install
+- script: |
+    git submodule update --init
+    npm install
   displayName: Install Dependencies
 
 - script: npm test

--- a/azure-pipelines/publish.yml
+++ b/azure-pipelines/publish.yml
@@ -42,7 +42,9 @@ extends:
               - 16.x
 
         testSteps:
-          - script: npm ci
+          - script: |
+              git submodule update --init
+              npm ci
             displayName: Install dependencies
 
           - script: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/spdlog",
-      "version": "0.13.8",
-      "hasInstallScript": true,
+      "version": "0.13.9",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.8",
+  "version": "0.13.9",
   "description": "Node bindings for spdlog",
   "main": "index.js",
   "types": "index.d.ts",
@@ -8,8 +8,6 @@
     "ui": "tdd"
   },
   "scripts": {
-    "preinstall": "git submodule update --init",
-    "install": "node-gyp rebuild",
     "dev": "cp -R ~/.node-gyp/$(node -p 'process.versions.node')/include/node deps/node",
     "test": "mocha"
   },


### PR DESCRIPTION
Npm packages are not git repositories, so the preinstall script will fail as seen in https://dev.azure.com/monacotools/Monaco/_build/results?buildId=209250

The deps is already expanded before we publish to NPM, so it is not required to have the submodule step.