### PR TITLE
fix: CI warnings and 32-bit compile errors

### DIFF
--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -13,4 +13,4 @@ steps:
     $env:npm_config_arch="$(NPM_ARCH)"
     npm test
   displayName: Run Tests
-  condition: eq("$(NPM_ARCH)", "x64")
+  condition: eq($(NPM_ARCH), 'x64')

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -13,4 +13,4 @@ steps:
     $env:npm_config_arch="$(NPM_ARCH)"
     npm test
   displayName: Run Tests
-  condition: eq($(NPM_ARCH), 'x64')
+  condition: eq(variables.NPM_ARCH, 'x64')

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -13,3 +13,4 @@ steps:
     $env:npm_config_arch="$(NPM_ARCH)"
     npm test
   displayName: Run Tests
+  condition: eq("$(NPM_ARCH)", "x64")

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -3,8 +3,9 @@ steps:
   inputs:
     versionSpec: "16.x"
 
-- script: |
+- powershell: |
     git submodule update --init
+    $env:npm_config_arch="$(ARCH)"
     npm install
   displayName: Install Dependencies
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -9,5 +9,7 @@ steps:
     npm install
   displayName: Install Dependencies
 
-- script: npm test
+- powershell: |
+    $env:npm_config_arch="$(NPM_ARCH)"
+    npm test
   displayName: Run Tests

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -5,7 +5,7 @@ steps:
 
 - powershell: |
     git submodule update --init
-    $env:npm_config_arch="$(ARCH)"
+    $env:npm_config_arch="$(NPM_ARCH)"
     npm install
   displayName: Install Dependencies
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -10,7 +10,6 @@ steps:
   displayName: Install Dependencies
 
 - powershell: |
-    $env:npm_config_arch="$(NPM_ARCH)"
     npm test
   displayName: Run Tests
   condition: eq(variables.NPM_ARCH, 'x64')

--- a/azure-pipelines/ci.yml
+++ b/azure-pipelines/ci.yml
@@ -5,21 +5,35 @@ trigger:
     include: ['*']
 
 jobs:
-- job: Windows
+- job: Windows64
   pool:
     vmImage: 'windows-latest'
+  env:
+    ARCH: 'x64'
+  steps:
+  - template: build.yml
+
+- job: Windows32
+  pool:
+    vmImage: 'windows-latest'
+  env:
+    ARCH: 'ia32'
   steps:
   - template: build.yml
 
 - job: macOS
   pool:
     vmImage: 'macOS-latest'
+  env:
+    ARCH: 'x64'
   steps:
   - template: build.yml
 
 - job: Linux
   pool:
     vmImage: 'Ubuntu-latest'
+  env:
+    ARCH: 'x64'
   dependsOn:
   - Windows
   - macOS

--- a/azure-pipelines/ci.yml
+++ b/azure-pipelines/ci.yml
@@ -35,7 +35,8 @@ jobs:
   variables:
     NPM_ARCH: 'x64'
   dependsOn:
-  - Windows
+  - Windows64
+  - Windows32
   - macOS
   steps:
   - template: build.yml

--- a/azure-pipelines/ci.yml
+++ b/azure-pipelines/ci.yml
@@ -8,32 +8,32 @@ jobs:
 - job: Windows64
   pool:
     vmImage: 'windows-latest'
-  env:
-    ARCH: 'x64'
+  variables:
+    NPM_ARCH: 'x64'
   steps:
   - template: build.yml
 
 - job: Windows32
   pool:
     vmImage: 'windows-latest'
-  env:
-    ARCH: 'ia32'
+  variables:
+    NPM_ARCH: 'ia32'
   steps:
   - template: build.yml
 
 - job: macOS
   pool:
     vmImage: 'macOS-latest'
-  env:
-    ARCH: 'x64'
+  variables:
+    NPM_ARCH: 'x64'
   steps:
   - template: build.yml
 
 - job: Linux
   pool:
     vmImage: 'Ubuntu-latest'
-  env:
-    ARCH: 'x64'
+  variables:
+    NPM_ARCH: 'x64'
   dependsOn:
   - Windows
   - macOS

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -111,14 +111,17 @@ NAN_METHOD(Logger::New) {
         if (!logger) {
 #if defined(_WIN32)
           const std::string utf8Filename = *Nan::Utf8String(info[2]);
-          const int bufferLen = MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, NULL, 0);
+          const int bufferLen = MultiByteToWideChar(
+              CP_UTF8, 0, utf8Filename.c_str(),
+              static_cast<int>(utf8Filename.size()), NULL, 0);
           if (!bufferLen) {
             return Nan::ThrowError(
               Nan::Error("Failed to determine buffer length for converting filename to wstring"));
           }
-          std::wstring fileName;
-          fileName.resize(bufferLen);
-          const int status = MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, &fileName[0], bufferLen);
+          std::wstring fileName(bufferLen, 0);
+          const int status = MultiByteToWideChar(
+              CP_UTF8, 0, utf8Filename.c_str(),
+              static_cast<int>(utf8Filename.size()), &fileName[0], bufferLen);
           if (!status) {
             return Nan::ThrowError(
               Nan::Error("Failed to convert filename to wstring"));

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -112,6 +112,10 @@ NAN_METHOD(Logger::New) {
 #if defined(_WIN32)
           const std::string utf8Filename = *Nan::Utf8String(info[2]);
           const int bufferLen = MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, NULL, 0);
+          if (!bufferLen) {
+            return Nan::ThrowError(
+              Nan::Error("Failed to convert filename to wstring"));
+          }
           std::wstring fileName;
           fileName.resize(bufferLen);
           MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, &fileName[0], bufferLen);

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -114,11 +114,15 @@ NAN_METHOD(Logger::New) {
           const int bufferLen = MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, NULL, 0);
           if (!bufferLen) {
             return Nan::ThrowError(
-              Nan::Error("Failed to convert filename to wstring"));
+              Nan::Error("Failed to determine buffer length for converting filename to wstring"));
           }
           std::wstring fileName;
           fileName.resize(bufferLen);
-          MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, &fileName[0], bufferLen);
+          const int status = MultiByteToWideChar(CP_UTF8, 0, utf8Filename.c_str(), -1, &fileName[0], bufferLen);
+          if (!status) {
+            return Nan::ThrowError(
+              Nan::Error("Failed to convert filename to wstring"));
+          }
 #else
           const std::string fileName = *Nan::Utf8String(info[2]);
 #endif


### PR DESCRIPTION
This PR fixes some warnings that showed up:
- There's a warning that codecvt isn't in C++17, and that MultiByteToWideChar should be used instead
- There's conversion errors in the parameters for `rotating_logger_st` that cause the build to fail for Windows 32-bit.