### PR TITLE
chore: skip reporting C4244 as error

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -19,7 +19,7 @@
 				'ExceptionHandling': 1,
 				'AdditionalOptions': [
 					'/guard:cf',
-					'/we4244',
+					'/w34244',
 					'/we4267',
 					'/ZH:SHA_256'
 				]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/spdlog",
-      "version": "0.13.10",
+      "version": "0.13.11",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.10",
+  "version": "0.13.11",
   "description": "Node bindings for spdlog",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
C4244 warnings in V8 headers are hard to address in terms of release timeline, currently we have one with https://github.com/microsoft/vscode/pull/180466 blocking exploration builds

```
node-gyp\Cache\24.0.0\include\node\v8-platform.h(1092,17): error C4244: 'return': conversion from 'double' to 'int64_t', possible loss of data [D:\a\_work\1\s\node_modules\@vscode\spdlog\build\spdlog.vcxproj]
```