### PR TITLE
spdlog version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.11",
+  "version": "0.13.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/spdlog",
-      "version": "0.13.11",
+      "version": "0.13.13",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.13.12",
+  "version": "0.13.13",
   "description": "Node bindings for spdlog",
   "main": "index.js",
   "types": "index.d.ts",

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -54,7 +54,7 @@ suite('API', function () {
 	});
 
 	test('Version', function () {
-		assert.strictEqual(spdlog.version, 11100);
+		assert.strictEqual(spdlog.version, 11200);
 	});
 
 	test('Logger is present', function () {


### PR DESCRIPTION
Alpine 3.19 got rid of lfs64
https://gitlab.alpinelinux.org/alpine/aports/-/commit/cab9b787b39387f0b3d30d218b0739c3e21aefb8

So spdlog fixed by not using it in musl
https://github.com/gabime/spdlog/commit/287a00d364990edbb621fe5e392aeb550135fb96

A small spdlog update is required to install vscode in Alpine 3.19

Installing @vscode/spdlog with spdlog v1.11.0 in Alpine 3.19
```
10.55 npm ERR! ../deps/spdlog/include/spdlog/details/os-inl.h:241:19: error: aggregate 'spdlog::details::os::filesize(FILE*)::stat64 st' has incomplete type and cannot be defined
10.55 npm ERR!   241 |     struct stat64 st;
10.55 npm ERR!       |                   ^~
10.55 npm ERR! ../deps/spdlog/include/spdlog/details/os-inl.h:242:11: error: '::fstat64' has not been declared; did you mean 'stat64'?
10.55 npm ERR!   242 |     if (::fstat64(fd, &st) == 0)
10.55 npm ERR!       |           ^~~~~~~
10.55 npm ERR!       |           stat64
```

Installing @vscode/spdlog with spdlog v1.12.0 in Alpine 3.19 works like a charm!