### PR TITLE
feat: support configure pattern time type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,11 @@ export enum LogLevel {
     Off
 }
 
+export enum PatternTimeType {
+    Local,
+    UTC,
+}
+
 export class Logger {
     constructor(loggerType: "rotating" | "rotating_async" | "stdout_async", name: string, filename: string, filesize: number, filecount: number);
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ exports.version = spdlog.version;
 exports.setLevel = spdlog.setLevel;
 exports.setFlushOn = spdlog.setFlushOn;
 exports.Logger = spdlog.Logger;
+exports.PatternTimeType = spdlog.PatternTimeType;
 
 function createRotatingLogger(name, filepath, maxFileSize, maxFiles) {
 	return createLogger('rotating', name, filepath, maxFileSize, maxFiles);

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -180,9 +180,15 @@ void Logger::SetPattern(const Napi::CallbackInfo& info) {
     throw Napi::Error::New(env, "Provide pattern");
   }
 
+  auto time_type = spdlog::pattern_time_type::local;
+  if (info[1].IsNumber()) {
+    time_type = static_cast<spdlog::pattern_time_type>(
+        info[1].As<Napi::Number>().DoubleValue());
+  }
+
   const std::string pattern = info[0].As<Napi::String>();
   if (logger_) {
-    logger_->set_pattern(pattern);
+    logger_->set_pattern(pattern, time_type);
   }
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -44,6 +44,11 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("setLevel", Napi::Function::New(env, SetLevel));
   exports.Set("setFlushOn", Napi::Function::New(env, SetFlushOn));
 
+  Napi::Object obj = Napi::Object::New(env);
+  obj.Set("Local", Napi::Number::New(env, static_cast<double>(spdlog::pattern_time_type::local)));
+  obj.Set("UTC", Napi::Number::New(env, static_cast<double>(spdlog::pattern_time_type::utc)));
+  exports.Set("PatternTimeType", obj);
+
   Logger::Init(env, exports);
   return exports;
 }

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -283,6 +283,30 @@ suite('API', function () {
 		assert.strictEqual(actual, 'This message should be written as is');
 	});
 
+	test('set pattern with time type local', async function () {
+		testObject = await aTestObject(logFile);
+		testObject.setPattern('[%z]', spdlog.PatternTimeType.Local);
+
+		let currentTimeZone = new Date().getTimezoneOffset();
+		currentTimeZone = (currentTimeZone/60) * -1;
+		testObject.info('This message should be written as is');
+
+		const str = `[${currentTimeZone < 0 ? '' : '+'}${currentTimeZone.toString().padStart(2, '0')}:00]`;
+		const actual = await getLastLine();
+		assert.strictEqual(actual, str);
+	});
+
+	test('set pattern with time type UTC', async function () {
+		testObject = await aTestObject(logFile);
+
+		testObject.setPattern('[%z]', spdlog.PatternTimeType.UTC);
+
+		testObject.info('This message should be written as is');
+
+		const actual = await getLastLine();
+		assert.strictEqual(actual, '[+00:00]');
+	});
+
 	test('clear formatters', async function () {
 		testObject = await aTestObject(logFile);
 


### PR DESCRIPTION
`spdlog` allowed user to logging UTC time, not local time: https://github.com/gabime/spdlog/pull/451

