### PR TITLE
fix: unhandled exception when failing to create log files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/spdlog",
-      "version": "0.15.1",
+      "version": "0.15.2",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.15.1",
+  "version": "0.15.2",
   "description": "Node bindings for spdlog",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/logger.cc
+++ b/src/logger.cc
@@ -76,18 +76,26 @@ Logger::Logger(const Napi::CallbackInfo& info)
 #else
       const std::string fileName = info[2].As<Napi::String>();
 #endif
-      if (logName == "rotating_async") {
-        logger_ = spdlog::rotating_logger_st<spdlog::async_factory>(
-            logName, fileName, static_cast<size_t>(info[3].As<Napi::Number>().Int64Value()),
-            static_cast<size_t>(info[4].As<Napi::Number>().Int64Value()));
-      } else {
-        logger_ = spdlog::rotating_logger_st(
-            logName, fileName, static_cast<size_t>(info[3].As<Napi::Number>().Int64Value()),
-            static_cast<size_t>(info[4].As<Napi::Number>().Int64Value()));
+      try {
+        if (logName == "rotating_async") {
+          logger_ = spdlog::rotating_logger_st<spdlog::async_factory>(
+              logName, fileName, static_cast<size_t>(info[3].As<Napi::Number>().Int64Value()),
+              static_cast<size_t>(info[4].As<Napi::Number>().Int64Value()));
+        } else {
+          logger_ = spdlog::rotating_logger_st(
+              logName, fileName, static_cast<size_t>(info[3].As<Napi::Number>().Int64Value()),
+              static_cast<size_t>(info[4].As<Napi::Number>().Int64Value()));
+        }
+      } catch (const spdlog::spdlog_ex& ex) {
+        throw Napi::Error::New(env, ex.what());
       }
     }
   } else {
-    logger_ = spdlog::stdout_logger_st<spdlog::async_factory>(name);
+    try {
+      logger_ = spdlog::stdout_logger_st<spdlog::async_factory>(name);
+    } catch (const spdlog::spdlog_ex& ex) {
+      throw Napi::Error::New(env, ex.what());
+    }
   }
 }
 

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -68,7 +68,7 @@ suite('API', function () {
 		assert.ok(fs.existsSync(logFile));
 	});
 
-	test('throws error when failed to create logfile', async function () {
+	(process.platform === 'win32' ? test : test.skip)('throws error when failed to create logfile', async function () {
 		let failedToThrow = false;
 		try {
 			await aTestObject(invalidLogFile);

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -14,6 +14,7 @@ suite('API', function () {
 
 	var tempDirectory;
 	var logFile;
+	var invalidLogFile;
 	var EOL = '\n';
 	var testObject;
 
@@ -22,6 +23,7 @@ suite('API', function () {
 	suiteSetup(() => {
 		tempDirectory = path.join(__dirname, 'logs');
 		logFile = path.join(tempDirectory, 'test.log');
+		invalidLogFile = path.join(tempDirectory, 'test*.log');
 		filesToDelete.push(logFile);
 		if (fs.existsSync(logFile)) {
 			fs.unlinkSync(logFile);
@@ -64,6 +66,17 @@ suite('API', function () {
 	test('Create rotating logger', async function () {
 		testObject = await aTestObject(logFile);
 		assert.ok(fs.existsSync(logFile));
+	});
+
+	test('throws error when failed to create logfile', async function () {
+		let failedToThrow = false;
+		try {
+			await aTestObject(invalidLogFile);
+			failedToThrow = true;
+		} catch (err) {
+			assert.ok(err instanceof Error);
+		}
+		assert.strictEqual(failedToThrow, false);
 	});
 
 	test('Log setFlushOn', async function () {


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/250616

Failing to create log files ended up as exceptions instead we now properly surface them to be handled as JS exceptions.