### PR TITLE
fix: disable fmt consteval to fix C++20 build with Clang 21

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,10 @@
 			"<!(node -p \"require('node-addon-api').include_dir\")",
 			"deps/spdlog/include"
 		],
-		"defines": [ "NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS" ],
+		"defines": [
+			"NODE_API_SWALLOW_UNTHROWABLE_EXCEPTIONS",
+			"FMT_CONSTEVAL="
+		],
 		'msvs_configuration_attributes': {
 			'SpectreMitigation': 'Spectre'
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/spdlog",
-      "version": "0.15.7",
+      "version": "0.15.8",
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/spdlog",
-  "version": "0.15.7",
+  "version": "0.15.8",
   "description": "Node bindings for spdlog",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fix the following error without bumping to newer spdlog version

```
In file included from ../deps/spdlog/include/spdlog/pattern_formatter-inl.h:10:
../deps/spdlog/include/spdlog/details/fmt_helper.h:105:54: error: call to consteval function 'fmt::basic_format_string<char, int &>::basic_format_string<FMT_COMPILE_STRING, 0>' is
      not a constant expression
  105 |         fmt_lib::format_to(std::back_inserter(dest), SPDLOG_FMT_STRING("{:02}"), n);
      |                                                      ^
../deps/spdlog/include/spdlog/common.h:54:46: note: expanded from macro 'SPDLOG_FMT_STRING'
   54 | #    define SPDLOG_FMT_STRING(format_string) FMT_STRING(format_string)
      |                                              ^
../deps/spdlog/include/spdlog/fmt/bundled/format.h:1772:23: note: expanded from macro 'FMT_STRING'
 1772 | #define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )

```